### PR TITLE
Set default language

### DIFF
--- a/src/diploma.tex
+++ b/src/diploma.tex
@@ -143,6 +143,7 @@ aboveskip=10pt}
 % Table of contents and the main text
 %--------------------------------------------------------------------------------------
 \begin{document}
+\selectlanguage{magyar}
 \singlespacing
 \include{guideline}
 \include{project}


### PR DESCRIPTION
The default language appears to be `english` (eg. the date in [`declaration.tex`](https://github.com/FTSRG/thesis-template-latex/blob/master/src/declaration.tex#L15))
