### PR TITLE
Set encoding for the TeXlipse project

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=utf-8


### PR DESCRIPTION
The imported TeXclipse project had the default encoding of the workspace, which is Cp1250 for me.
With this change, the project has its encoding set to `utf8`, which should match with the actual encoding of the  files.