### PR TITLE
[WIP] Make TDK titlepages language independent

### DIFF
--- a/src/include/titlepage_otdk.tex
+++ b/src/include/titlepage_otdk.tex
@@ -11,7 +11,7 @@
 	\vspace{13cm}
 	
 	\Large
-	\hspace{8cm} \vikszerzoVezeteknev{} \vikszerzoKeresztnev
+	\hspace{8cm} \szerzo
 	
 	\hspace{8cm} \tdkszerzoB
 	
@@ -28,8 +28,8 @@
   \includegraphics[width=7cm]{./figures/bme_logo.pdf}
   \vspace{0.3cm}
   
-  Budapesti Műszaki és Gazdaságtudományi Egyetem \\
-  Villamosmérnöki és Informatikai Kar \\
+  \bme \\
+  \vik \\
   \viktanszek \\
   \vspace{3.5cm}
   
@@ -40,12 +40,12 @@
   \vfill
     
   {\Large 
-  	{\large Készítette:} \\ \vspace{0.2cm}
-  	\vikszerzoVezeteknev{} \vikszerzoKeresztnev \\ \tdkevfolyamA. évfolyam \\
+  	{\large \keszitette:} \\ \vspace{0.2cm}
+  	\szerzo \\ \tdkevfolyamA. évfolyam \\
 	\vspace{0.5cm}
 	\tdkszerzoB \\ \tdkevfolyamB. évfolyam \\
   	\vspace{1.5cm}
-  	{\large Konzulens:} \\ \vspace{0.2cm}
+  	{\large \konzulens:} \\ \vspace{0.2cm}
   	\vikkonzulensA,\\ \tdkkonzulensbeosztasA \\
   	\vspace{0.5cm}
   	\vikkonzulensB,\\ \tdkkonzulensbeosztasB \\

--- a/src/include/titlepage_tdk.tex
+++ b/src/include/titlepage_tdk.tex
@@ -4,8 +4,8 @@
   \includegraphics[width=7cm]{./figures/bme_logo.pdf}
   \vspace{0.3cm}
   
-  Budapesti Műszaki és Gazdaságtudományi Egyetem \\
-  Villamosmérnöki és Informatikai Kar \\
+  \bme \\
+  \vik \\
   \viktanszek \\
   \vspace{5cm}
   
@@ -16,11 +16,11 @@
   \vfill
     
   {\Large 
-  	Készítette: \\ \vspace{0.3cm}
-  	\vikszerzoVezeteknev{} \vikszerzoKeresztnev \\
+  	\keszitette: \\ \vspace{0.3cm}
+  	\szerzo \\
 	\tdkszerzoB \\
   	\vspace{1.5cm}
-  	Konzulens: \\ \vspace{0.3cm}
+  	\konzulens: \\ \vspace{0.3cm}
   	\vikkonzulensA \\
   	\vikkonzulensB \\
   }


### PR DESCRIPTION
Currently both TDK docs have a Hungarian titlepage.
If it's not a requirement, it should be changed to use the language-specific commands.

I'm not quite sure how would I change `\tdkevfolyamA. évfolyam`. Having a separate command, so that it produces `III. year or grade` just looks weird. `Year III` also.