### PR TITLE
Migrate to container-based Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 addons:
   apt:
     packages:
+    - lmodern
+    - texlive-latex-recommended
     - texlive-latex-extra
     - texlive-fonts-extra
     - texlive-fonts-recommended

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
-before_script:
-  - sudo apt-get install -y texlive-latex-extra texlive-fonts-extra texlive-fonts-recommended texlive-xetex texlive-science
-
+addons:
+  apt:
+    packages:
+    - texlive-latex-extra
+    - texlive-fonts-extra
+    - texlive-fonts-recommended
+    - texlive-xetex
+    - texlive-science
 script:
   - cd src
   - make test


### PR DESCRIPTION
Travis is showing a warning for [6e80b62](https://travis-ci.org/FTSRG/thesis-template-latex/builds/80977116) for using [their legacy infrastructure](http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade).

This PR eliminates the direct apt-get command and uses Travis' addon for the same to enable the container-based infrastructure.

This way also a bit fewer packages are needed for the build to download.