### PR TITLE
List of figures, tables and bibliography title fix

### DIFF
--- a/src/include/thesis-en.tex
+++ b/src/include/thesis-en.tex
@@ -21,10 +21,14 @@
 
 \newcommand{\bevezetes}{Introduction}
 \newcommand{\koszonetnyilvanitas}{Acknowledgements}
-\newcommand{\abrakjegyzeke}{List of Figures}
-\newcommand{\tablazatokjegyzeke}{List of Tables}
-\newcommand{\irodalomjegyzek}{Bibliography}
 \newcommand{\fuggelek}{Appendix}
+
+% Optional custom titles
+%\addto\captionsenglish{%
+%\renewcommand*{\listfigurename}{Your list of figures title}
+%\renewcommand*{\listtablename}{Your list of tables title}
+%\renewcommand*{\bibname}{Your bibliography title}
+%}
 
 \newcommand{\szerzo}{\vikszerzoKeresztnev{} \vikszerzoVezeteknev}
 \newcommand{\vikkonzulensA}{\vikkonzulensAMegszolitas\vikkonzulensAKeresztnev{} \vikkonzulensAVezeteknev}

--- a/src/include/thesis-hu.tex
+++ b/src/include/thesis-hu.tex
@@ -21,10 +21,14 @@
 
 \newcommand{\bevezetes}{Bevezetés}
 \newcommand{\koszonetnyilvanitas}{Köszönetnyilvánítás}
-\newcommand{\abrakjegyzeke}{Ábrák jegyzéke}
-\newcommand{\tablazatokjegyzeke}{Táblázatok jegyzéke}
-\newcommand{\irodalomjegyzek}{Irodalomjegyzék}
 \newcommand{\fuggelek}{Függelék}
+
+% Opcionálisan átnevezhető címek
+%\addto\captionsmagyar{%
+%\renewcommand{\listfigurename}{Saját ábrajegyzék cím}
+%\renewcommand{\listtablename}{Saját táblázatjegyzék cím}
+%\renewcommand{\bibname}{Saját irodalomjegyzék név}
+%}
 
 \newcommand{\szerzo}{\vikszerzoVezeteknev{} \vikszerzoKeresztnev}
 \newcommand{\vikkonzulensA}{\vikkonzulensAMegszolitas\vikkonzulensAVezeteknev{} \vikkonzulensAKeresztnev}

--- a/src/thesis.tex
+++ b/src/thesis.tex
@@ -88,14 +88,14 @@
 
 % List of Figures, Tables
 %~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-%\listoffigures\addcontentsline{toc}{chapter}{\abrakjegyzeke}
-%\listoftables\addcontentsline{toc}{chapter}{\tablazatokjegyzeke}
+%\listoffigures\addcontentsline{toc}{chapter}{\listfigurename}
+%\listoftables\addcontentsline{toc}{chapter}{\listtablename}
 
 
 % Bibliography
 %~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 \bibliography{bib/mybib}
-\addcontentsline{toc}{chapter}{\irodalomjegyzek}
+\addcontentsline{toc}{chapter}{\bibname}
 
 
 % Appendix


### PR DESCRIPTION
Fixed optional custom titles for the LoF, LoT and for the bibliography.  The previous commands used for this only affected the table of contents, but they happened to have the same values as default, thus hiding this error.  I have added some commented lines in both languages that show how to use custom titles, if needed.