### PR TITLE
Alapértelmezett aláosztások számának módosítása

### DIFF
--- a/src/include/preamble.tex
+++ b/src/include/preamble.tex
@@ -9,9 +9,9 @@
 \pagestyle{plain}
 \marginsize{35mm}{25mm}{15mm}{15mm}
 
-\setcounter{secnumdepth}{0}
+\setcounter{tocdepth}{3}
 %\sectionfont{\large\upshape\bfseries}
-\setcounter{secnumdepth}{2}
+\setcounter{secnumdepth}{3}
 
 \sloppy % Margón túllógó sorok tiltása.
 \widowpenalty=10000 \clubpenalty=10000 %A fattyú- és árvasorok elkerülése


### PR DESCRIPTION
> A fejezeteket decimális aláosztással számozzuk, maximálisan 3 aláosztás mélységben (pl. 2.3.4.1.). 

Alapértelmezetetten a subsubsection alfejezet nem számozva jelenik meg. 

A premable fájlban ez látható a setcounter beállításnál:

```
\setcounter{secnumdepth}{0}
%\sectionfont{\large\upshape\bfseries}
\setcounter{secnumdepth}{2}
```
Javasolni szeretném a `\setcounter{secnumdepth}{2}`értékét 2-ről 3-ra módosítani. Ezt követően a subsubsection már számozva jelenik meg. 

Valamint a \setcounter beállítás kétszer kap értéket, először 0 majd 2 értéket. Rögtön egymás után. Javaslom az egyik törlését.

Mivel az aláosztásokat növeltük, a tartalomjegyzéknél is kell a mélységet növelni, módosítottam tehát erre:
`\setcounter{tocdepth}{3}`