### PR TITLE
Fixing page number in TOC for References chapter

### DIFF
--- a/src/thesis.tex
+++ b/src/thesis.tex
@@ -94,8 +94,8 @@
 
 % Bibliography
 %~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-\bibliography{bib/mybib}
 \addcontentsline{toc}{chapter}{\bibname}
+\bibliography{bib/mybib}
 
 
 % Appendix


### PR DESCRIPTION
Currently if References is more than one page long then the TOC contains the number of the last page of References.

Placing `\addcontentsline` before `\bibliography` fixes this.