### PR TITLE
Fix slanted lmodern lighttt in lstlisting on pdflatex

### DIFF
--- a/src/include/packages.tex
+++ b/src/include/packages.tex
@@ -12,6 +12,7 @@
   \usepackage[T1]{fontenc}
   \usepackage[utf8]{inputenc}
   \usepackage[lighttt]{lmodern}
+  \ttfamily\DeclareFontShape{T1}{lmtt}{m}{it}{<->sub*lmtt/m/sl}{}
 \fi
 
 \usepackage[english,magyar]{babel} % Alapértelmezés szerint utoljára definiált nyelv lesz aktív, de később külön beállítjuk az aktív nyelvet.


### PR DESCRIPTION
Fixes #60 

I have only tested this with pdflatex on linux, it may be a non-problem for Windows machines.