### PR TITLE
Replace deprecated package anypage with geometry

### DIFF
--- a/src/include/packages.tex
+++ b/src/include/packages.tex
@@ -28,7 +28,7 @@
 %\usepackage{fancyhdr}
 %\usepackage{lastpage}
 
-\usepackage{anysize}
+\usepackage{geometry}
 %\usepackage{sectsty}
 \usepackage{setspace} % For setting line spacing
 

--- a/src/include/preamble.tex
+++ b/src/include/preamble.tex
@@ -7,7 +7,7 @@
 % (like the ToC, the References, and the Chapter pages)remain in plane style
 
 \pagestyle{plain}
-\marginsize{35mm}{25mm}{15mm}{15mm}
+\geometry{inner=35mm, outer=25mm, top=28mm, bottom=25mm}
 
 \setcounter{tocdepth}{3}
 %\sectionfont{\large\upshape\bfseries}


### PR DESCRIPTION
Closes #66 

Geometry calculates top and bottom margins differently. To get the same sized margins, the top margin would have to be 28.05 mm and the bottom margin 25.52 mm. I set 28 mm and 25 mm instead. The outcome is close enough.